### PR TITLE
dirname doesn't work when running from current directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ import os
 
 from setuptools import setup, find_packages
 
-baseDir = os.path.dirname(__file__)
+baseDir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(baseDir)
 
 def read(fname):


### PR DESCRIPTION
Because `__file__` just returns the file name if running setup.py from it's current directory.
See http://stackoverflow.com/a/12882176
