### PR TITLE
Option to not wait for startup message

### DIFF
--- a/src/ant/core/node.py
+++ b/src/ant/core/node.py
@@ -198,7 +198,7 @@ class Node(object):
         if wait:
             evm.waitForMessage(message.StartupMessage)
     
-    def start(self):
+    def start(self, wait=True):
         if self.running:
             raise NodeError('Could not start ANT node (already started).')
         
@@ -206,7 +206,7 @@ class Node(object):
         evm.start(name=self.name)
         
         try:
-            self.reset()
+            self.reset(wait)
             msg = message.ChannelRequestMessage(messageID=MESSAGE_CAPABILITIES)
             caps = evm.writeMessage(msg).waitForMessage(message.CapabilitiesMessage)
         except MessageError as err:


### PR DESCRIPTION
ANT+ documentation states that the start-up message is only available on specific devices. The `waitForMessage` kept timing out for me, so I assume my device doesn't implement the message. This change allows users to specify whether or not they want to wait for it.
